### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/nanoFramework.Telegram.Bot.Example/nanoFramework.Telegram.Bot.Example.nfproj
+++ b/nanoFramework.Telegram.Bot.Example/nanoFramework.Telegram.Bot.Example.nfproj
@@ -47,8 +47,8 @@
     <Reference Include="nanoFramework.System.Text">
       <HintPath>..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi">
-      <HintPath>..\packages\nanoFramework.System.Device.Wifi.1.5.133\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.134.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Device.Wifi.1.5.134\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams">
       <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>

--- a/nanoFramework.Telegram.Bot.Example/packages.config
+++ b/nanoFramework.Telegram.Bot.Example/packages.config
@@ -5,7 +5,7 @@
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.133" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.134" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.43" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net.Http.Client" version="1.5.196" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.System.Device.Wifi from 1.5.133 to 1.5.134</br>
[version update]

### :warning: This is an automated update. :warning:
