### PR TITLE
Update 5 NuGet dependencies

### DIFF
--- a/nanoFramework.Telegram.Bot.Example/nanoFramework.Telegram.Bot.Example.nfproj
+++ b/nanoFramework.Telegram.Bot.Example/nanoFramework.Telegram.Bot.Example.nfproj
@@ -47,17 +47,17 @@
     <Reference Include="nanoFramework.System.Text">
       <HintPath>..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.139.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.Wifi.1.5.139\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.141.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Device.Wifi.1.5.141\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams">
       <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.11.47\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.50.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.11.50\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.200.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.Http.Client.1.5.200\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.204.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.Http.Client.1.5.204\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading">
       <HintPath>..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/nanoFramework.Telegram.Bot.Example/packages.config
+++ b/nanoFramework.Telegram.Bot.Example/packages.config
@@ -5,10 +5,10 @@
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.139" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.141" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.47" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http.Client" version="1.5.200" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.50" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http.Client" version="1.5.204" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
 </packages>

--- a/nanoFramework.Telegram.Bot.Tests/nanoFramework.Telegram.Bot.Tests.nfproj
+++ b/nanoFramework.Telegram.Bot.Tests/nanoFramework.Telegram.Bot.Tests.nfproj
@@ -46,8 +46,8 @@
     <Reference Include="mscorlib">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.203.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Json.2.2.203\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.210.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Json.2.2.210\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager">
       <HintPath>..\packages\nanoFramework.ResourceManager.1.2.32\lib\nanoFramework.ResourceManager.dll</HintPath>
@@ -76,11 +76,11 @@
     <Reference Include="System.IO.Streams">
       <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.11.47\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.50.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.11.50\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.200.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.Http.1.5.200\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.204.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.Http.1.5.204\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading">
       <HintPath>..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/nanoFramework.Telegram.Bot.Tests/packages.config
+++ b/nanoFramework.Telegram.Bot.Tests/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.203" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.210" targetFramework="netnano1.0" />
   <package id="nanoFramework.ResourceManager" version="1.2.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.87" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.47" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.200" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.50" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.204" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="3.0.77" targetFramework="netnano1.0" developmentDependency="true" />

--- a/nanoFramework.Telegram.Bot.nuspec
+++ b/nanoFramework.Telegram.Bot.nuspec
@@ -19,8 +19,8 @@
     <tags>nanoFramework C# csharp Telegram tg bot client</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.Json" version="2.2.203" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.200" />
+      <dependency id="nanoFramework.Json" version="2.2.210" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.204" />
     </dependencies>
   </metadata>
   <files>

--- a/nanoFramework.Telegram.Bot/nanoFramework.Telegram.Bot.nfproj
+++ b/nanoFramework.Telegram.Bot/nanoFramework.Telegram.Bot.nfproj
@@ -64,8 +64,8 @@
     <Reference Include="mscorlib">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.203.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Json.2.2.203\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.210.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Json.2.2.210\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events">
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
@@ -79,11 +79,11 @@
     <Reference Include="System.IO.Streams">
       <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.11.47\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.50.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.11.50\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.200.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.Http.1.5.200\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.204.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.Http.1.5.204\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading">
       <HintPath>..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/nanoFramework.Telegram.Bot/packages.config
+++ b/nanoFramework.Telegram.Bot/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.203" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.210" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.47" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.200" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.50" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.204" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.9.50" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.Json from 2.2.203 to 2.2.210</br>Bumps nanoFramework.System.Net from 1.11.47 to 1.11.50</br>Bumps nanoFramework.System.Net.Http from 1.5.200 to 1.5.204</br>Bumps nanoFramework.System.Device.Wifi from 1.5.139 to 1.5.141</br>Bumps nanoFramework.System.Net.Http.Client from 1.5.200 to 1.5.204</br>
[version update]

### :warning: This is an automated update. :warning:
